### PR TITLE
Fix axios base URL in frontend

### DIFF
--- a/socio-frontend/src/utils/axios.js
+++ b/socio-frontend/src/utils/axios.js
@@ -4,7 +4,11 @@
 
 import axios from 'axios';
 
-const axiosServices = axios.create({ baseURL: process.env.REACT_APP_API_URL || 'http://localhost:3010/' });
+// prefer NEXT_PUBLIC_BACKEND_URL for frontend requests and fall back to React style
+// environment variable or localhost
+const axiosServices = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_BACKEND_URL || process.env.REACT_APP_API_URL || 'http://localhost:8000/'
+});
 
 // interceptor for http
 axiosServices.interceptors.response.use(


### PR DESCRIPTION
## Summary
- fix axios base URL so the frontend uses NEXT_PUBLIC_BACKEND_URL

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_685220d565b0832c92771f28f9839065